### PR TITLE
Fix "pass by reference" error

### DIFF
--- a/src/AbstractAcmeClient.php
+++ b/src/AbstractAcmeClient.php
@@ -297,10 +297,11 @@ abstract class AbstractAcmeClient implements AcmeClientInterface
         $this->log(LogLevel::DEBUG, 'Generating Certificate Signing Request ...', [
             'csrData' => $csrData,
         ]);
-
+        
+        $privateKey = $domainKeyPair->getPrivateKey();
         $csr = openssl_csr_new(
             $csrData,
-            $domainKeyPair->getPrivateKey(),
+            $privateKey,
             ['digest_alg' => 'sha256']
         );
 


### PR DESCRIPTION
This resolves the following error:
Only variables should be passed by reference #0 /var/www/potatodash/vendor/acmephp/core/src/AbstractAcmeClient.php(303)
